### PR TITLE
Multiple fixes.

### DIFF
--- a/sote/game/entities/province.lua
+++ b/sote/game/entities/province.lua
@@ -57,6 +57,7 @@ local prov = {}
 ---@field foragers_limit number
 ---@field building_type_present fun(self:Province, building:BuildingType):boolean Returns true when a building of a given type has been built in a province
 ---@field local_resources table<Resource, Resource> A hashset containing all resources present on tiles of this province
+---@field local_resources_location {[1]: Tile, [2]: Resource}[] An array of local resources and their positions
 ---@field mood number how local population thinks about the state
 ---@field outlaws table<POP, POP>
 ---@field outlaw_pop fun(self:Province, pop:POP) Marks a pop as an outlaw
@@ -125,6 +126,7 @@ function prov.Province:new()
 	o.buildable_buildings = {}
 	o.hydration = 5
 	o.local_resources = {}
+	o.local_resources_location = {}
 	o.local_production = {}
 	o.local_consumption = {}
 	o.local_storage = {}

--- a/sote/game/raws/technologies.lua
+++ b/sote/game/raws/technologies.lua
@@ -56,6 +56,12 @@ function Technology:new(o)
 		r[k] = v
 	end
 	setmetatable(r, Technology)
+
+	if ASSETS.icons[r.icon] == nil then
+		print("Missing icon: " .. r.icon)
+		error("Technology " .. r.name .. " has no icon. " .. "Missing icon: " .. r.icon)
+	end
+
 	if RAWS_MANAGER.technologies_by_name[r.name] ~= nil then
 		local msg = "Failed to load a technology (" .. tostring(r.name) .. ")"
 		print(msg)

--- a/sote/game/raws/technology-loader.lua
+++ b/sote/game/raws/technology-loader.lua
@@ -138,7 +138,7 @@ function d.load()
 	}
 	Technology:new {
 		name = 'gem-cutting',
-		icon = 'cut-gems.png',
+		icon = 'ice-cube.png',
 		description = 'cutting exotic gemstones to please the eye',
 		r = 0.72,
 		g = 0.94,

--- a/sote/game/raws/technology-loader.lua
+++ b/sote/game/raws/technology-loader.lua
@@ -69,7 +69,7 @@ function d.load()
 		r = 1,
 		g = 1,
 		b = 1,
-		unlocked_by = { tec('ground-stone-tools') },
+		unlocked_by = { tec('pottery') },
 		required_resource = { res("meteoric-iron"), res("native-copper"), res("native-gold") },
 		research_cost = 0.25,
 	}

--- a/sote/game/raws/technology-loader.lua
+++ b/sote/game/raws/technology-loader.lua
@@ -63,6 +63,17 @@ function d.load()
 		research_cost = 0.25,
 	}
 	Technology:new {
+		name = 'pottery',
+		icon = 'powder.png',
+		description = 'pottery',
+		r = 0.23,
+		g = 0.23,
+		b = 0.23,
+		unlocked_by = { tec('paleolithic-knowledge') },
+		research_cost = 0.3,
+		required_resource = { res('quality-clay') },
+	}
+	Technology:new {
 		name = 'early-metal-working',
 		icon = 'asteroid.png',
 		description = 'cold working of native metals',
@@ -159,17 +170,7 @@ function d.load()
 		unlocked_by = { tec('dedicated-woodcutters') },
 		research_cost = 0.055,
 	}
-	Technology:new {
-		name = 'pottery',
-		icon = 'powder.png',
-		description = 'pottery',
-		r = 0.23,
-		g = 0.23,
-		b = 0.23,
-		unlocked_by = { tec('paleolithic-knowledge') },
-		research_cost = 0.3,
-		required_resource = { res('quality-clay') },
-	}
+
 	Technology:new {
 		name = 'pottery-wheel',
 		icon = 'powder.png',

--- a/sote/game/scenes/game.lua
+++ b/sote/game/scenes/game.lua
@@ -549,94 +549,177 @@ function gam.draw()
 	-- Just for debugging of tile graphics rendering
 	local province_on_map_interaction = false
 
-	if gam.camera_position:len() < 1.1 then
-		local mpfx = 0.5
-		local mpfy = 0.5
-		local vp = projection * view
-		local inv_vp = cpml.mat4.identity()
-		inv_vp:invert(vp)
-		local cp = inv_vp * cpml.vec3.new(
-			2 * mpfx - 1,
-			2 * mpfy - 1,
-			0
-		)
-		local coll_point, dist = cpml.intersect.ray_sphere({
-			position = gam.camera_position,
-			direction = (cp - gam.camera_position):normalize()
-		}, {
-			position = origin_point,
-			radius = 1.0
-		})
-		if coll_point then
-			local refx, refy = ui.get_reference_screen_dimensions()
-			local size = 35
-			local draw_tile = function(tile)
-				---@type Tile
-				local tile = tile
-				local lat, lon = tile:latlon()
-				local ll = require "game.latlon"
-				local cartx, carty, cartz = ll.lat_lon_to_cart(lat, lon)
-				coll_point.x = cartx
-				coll_point.y = carty
-				coll_point.z = cartz
-				local cart = coll_point;
-				local vv = vp * cart
-				vv.x = vv.x / 2
-				vv.y = vv.y / 2
-				vv.z = vv.z / 2
-				local x = (vv.x + 0.5) * refx
-				local y = (vv.y + 0.5) * refy
+	local mpfx = 0.5
+	local mpfy = 0.5
+	local vp = projection * view
+	local inv_vp = cpml.mat4.identity()
+	inv_vp:invert(vp)
+	local cp = inv_vp * cpml.vec3.new(
+		2 * mpfx - 1,
+		2 * mpfy - 1,
+		0
+	)
+	local coll_point, dist = cpml.intersect.ray_sphere({
+		position = gam.camera_position,
+		direction = (cp - gam.camera_position):normalize()
+	}, {
+		position = origin_point,
+		radius = 1.0
+	})
 
-				local province_visible = true
-				local character = WORLD.player_character
-				if character and character.realm then
-					province_visible = false
-					if character.realm.known_provinces[tile.province] then
-						province_visible = true
-					end
-				end
-				if (tile.is_land and province_visible) then
-					local rect = ui.rect(x - size / 2, y - size / 2, size, size)
-					if tile.province.realm and tile.province.center == tile then
-						if require "game.scenes.game.widgets.province-on-map" (gam, tile, rect, x, y, size) then
-							gam.click_callback = callback.nothing()
-						end
-					elseif tile.resource then
-						ui.image(ASSETS.get_icon(tile.resource.icon), rect)
-						--elseif tile.tile_improvement then
-						--ui.image(ASSETS.get_icon(tile.tile_improvement.type.map_texture), rect)
-					else
-						--[[
-						if tile.elevation > 2500.0 then
-							ui.image(ASSETS.get_icon("0_mountain.png"), rect)
-						else
-							ui.image(ASSETS.get_icon("oak.png"), rect)
-						end
-						--]]
-					end
-				end
+	local refx, refy = ui.get_reference_screen_dimensions()
+	local size = 35
 
-				return false
+	local rect_for_icons = ui.rect(0, 0, size, size)
+
+	---comment
+	---@param tile Tile
+	---@returns x number
+	---@returns y number
+	local function tile_to_x_y(tile)
+		local lat, lon = tile:latlon()
+		local ll = require "game.latlon"
+		local cartx, carty, cartz = ll.lat_lon_to_cart(lat, lon)
+		coll_point.x = cartx
+		coll_point.y = carty
+		coll_point.z = cartz
+		local cart = coll_point
+		local vv = vp * cart
+		vv.x = vv.x / 2
+		vv.y = vv.y / 2
+		vv.z = vv.z / 2
+		local x = (vv.x + 0.5) * refx
+		local y = (vv.y + 0.5) * refy
+
+		local z = gam.camera_position:dot(cart)
+
+		return x, y, z
+	end
+
+	if coll_point and ((gam.camera_position:len() < 1.15) or (gam.inspector == 'macrobuilder')) then
+		province_on_map_interaction = true
+		---comment
+		---@param province Province
+		local function draw_province(province)
+			-- sanity checks
+			local visibility = true
+			if WORLD.player_character then
+				visibility = false
+				if WORLD.player_character.realm.known_provinces[province] then
+					visibility = true
+				end
 			end
 
-			local visited = {}
-			---@type Queue<Tile>
-			local qq = require "engine.queue":new()
-			local to_draw = 3500
-			local center_tile = WORLD.tiles[tile.cart_to_index(coll_point.x, coll_point.y, coll_point.z)]
-			visited[center_tile] = center_tile
-			qq:enqueue(center_tile)
-			while qq:length() > 0 and to_draw > 0 do
-				to_draw = to_draw - 1
-				---@type Tile
-				local td = qq:dequeue()
-				draw_tile(td)
-				for n in td:iter_neighbors() do
-					if visited[n] then
-					else
-						visited[n] = n
-						qq:enqueue(n)
-					end
+			if not visibility then
+				return
+			end
+
+			local tile = province.center
+
+			if not province.realm then
+				return
+			end
+
+			-- get screen coordinates
+			local x, y, z = tile_to_x_y(tile)
+			rect_for_icons.x = x - size / 2
+			rect_for_icons.y = y - size / 2
+
+			-- check if on screen
+			if x < -refx * 0.5 or x > 1.5 * refx or y < -refy * 0.5 or y > 1.5 * refy then
+				return
+			end
+
+			-- check if on the opposite side of the globe
+			if z < 0 then
+				return
+			end
+
+			-- draw
+
+			if require "game.scenes.game.widgets.province-on-map" (gam, tile, rect_for_icons, x, y, size) then
+				gam.click_callback = callback.nothing()
+			else
+				province_on_map_interaction = false
+			end
+		end
+
+		-- drawing provinces
+		if gam.inspector == 'macrobuilder' then
+			local character = WORLD.player_character
+			if character then
+				for _, province in pairs(character.realm.known_provinces) do
+					draw_province(province)
+				end
+			end
+		end
+
+		---@type table<Province, Province>
+		local visited = {}
+		---@type Queue<Province>
+		local qq = require "engine.queue":new()
+		local to_draw = 200
+		local center_tile = WORLD.tiles[tile.cart_to_index(coll_point.x, coll_point.y, coll_point.z)]
+		visited[center_tile.province] = center_tile.province
+		qq:enqueue(center_tile.province)
+		while qq:length() > 0 and to_draw > 0 do
+			to_draw = to_draw - 1
+			local td = qq:dequeue()
+			draw_province(td)
+			for _, n in pairs(td.neighbors) do
+				if visited[n] then
+				else
+					visited[n] = n
+					qq:enqueue(n)
+				end
+			end
+		end
+	end
+
+	if coll_point and (gam.camera_position:len() < 1.15) then
+		local draw_tile = function(tile)
+			---@type Tile
+			local tile = tile
+			local x, y = tile_to_x_y(tile)
+
+			local province_visible = true
+			local character = WORLD.player_character
+			if character and character.realm then
+				province_visible = false
+				if character.realm.known_provinces[tile.province] then
+					province_visible = true
+				end
+			end
+			if (tile.is_land and province_visible) then
+				rect_for_icons.x = x - size / 2
+				rect_for_icons.y = y - size / 2
+				if tile.resource then
+					ui.image(ASSETS.get_icon(tile.resource.icon), rect_for_icons)
+				end
+			end
+
+			return false
+		end
+
+		-- drawing tile resources
+		---@type table<Tile, Tile>
+		local visited = {}
+		---@type Queue<Tile>
+		local qq = require "engine.queue":new()
+		local to_draw = 3500
+		local center_tile = WORLD.tiles[tile.cart_to_index(coll_point.x, coll_point.y, coll_point.z)]
+		visited[center_tile] = center_tile
+		qq:enqueue(center_tile)
+		while qq:length() > 0 and to_draw > 0 do
+			to_draw = to_draw - 1
+			---@type Tile
+			local td = qq:dequeue()
+			draw_tile(td)
+			for n in td:iter_neighbors() do
+				if visited[n] then
+				else
+					visited[n] = n
+					qq:enqueue(n)
 				end
 			end
 		end

--- a/sote/game/scenes/game/inspector-character.lua
+++ b/sote/game/scenes/game/inspector-character.lua
@@ -129,7 +129,7 @@ function window.draw(game)
 
     ui.panel(description_panel)
     description_panel:shrink(5)
-    ui.left_text(s, description_panel)
+    ui.text(s, description_panel, "left", 'up')
 
     traits_slider = ui.scrollview(
         traits_panel, 

--- a/sote/game/scenes/game/planet-shader.lua
+++ b/sote/game/scenes/game/planet-shader.lua
@@ -167,12 +167,12 @@ function pla.get_shader()
 
 					if (max3(abs(my_bord - player_bord)) < 0.0001) {
 						province_border_color = vec4(0.95, 0.1, 0.1, 1);
-						province_border_thickness = 0.2;
+						province_border_thickness = 0.35;
 					}
 
 					if (max3(abs(my_bord - clicked_bord)) < 0.0001) {
 						province_border_color = vec4(0.85, 0.4, 0.2, 1);
-						province_border_thickness = 0.4;
+						province_border_thickness = 0.3;
 					}
 
 					float up_b = (province_border_thickness - tile_uv.y);

--- a/sote/game/scenes/game/widgets/province-on-map.lua
+++ b/sote/game/scenes/game/widgets/province-on-map.lua
@@ -7,6 +7,100 @@ local ev = require "game.raws.values.economical"
 local ee = require "game.raws.effects.economic"
 local pv = require "game.raws.values.political"
 
+
+local function macrobuilder(gam, tile, rect, x, y, size)
+    local player_character = WORLD.player_character
+    if player_character == nil then
+        return
+    end
+    if player_character.realm ~= tile.province.realm then
+        return
+    end
+    ---@type BuildingType
+    local building_type = gam.selected.macrobuilder_building_type
+
+    if building_type then
+
+        local best_location = nil
+
+        if building_type.tile_improvement then
+            local best_eff = 0
+            local province = tile.province
+            if province and building_type then
+                for _, p_tile in pairs(province.tiles) do
+                    if not p_tile.tile_improvement then
+                        best_eff = math.max(best_eff, building_type.production_method:get_efficiency(p_tile))
+                        best_location = p_tile
+                    end
+                end
+            end
+        end
+
+        local public_flag = false
+        local overseer = player_character
+        local funds = player_character.savings
+        local owner = player_character
+
+        if gam.macrobuilder_public_mode then
+            overseer = pv.overseer(tile.province.realm)
+            public_flag = true
+            funds = player_character.realm.budget.treasury
+            owner = nil
+        end
+
+        if not tile.province:can_build(9999, building_type, best_location, overseer, public_flag) then
+            return
+        end
+
+        local icon = building_type.icon
+        local name = building_type.name
+
+        local amount = 0
+        
+        for _, building in pairs(tile.province.buildings) do
+            if building.type == building_type then
+                amount = amount + 1
+            end
+        end
+
+        local unit = size * 1.5
+
+        local rect = ui.rect(
+            x - unit / 2 ,
+            y - unit / 2,
+            unit,
+            unit
+        )
+
+        local construction_cost = ev.building_cost(
+            building_type,
+            overseer,
+            public_flag
+        )
+
+        local icon_rect = rect:subrect(0, 0, unit, unit, "left", 'up')
+        local count_rect = rect:subrect(0, unit, unit, unit / 2, "left", 'up')
+
+        if funds < construction_cost then
+            ut.icon_button(ASSETS.icons['cancel.png'], icon_rect, "Not possible to build", false)
+        elseif ut.icon_button(ASSETS.get_icon(icon), icon_rect, "Build " .. name .. " for " .. ut.to_fixed_point2(construction_cost) .. MONEY_SYMBOL ) then
+            return function()
+                ee.construct_building_with_payment(
+                    building_type,
+                    tile.province,
+                    best_location,
+                    owner,
+                    overseer,
+                    public_flag
+                )
+            end
+        end
+
+        ut.integer_entry("", amount, count_rect, "Current amount of buildings")
+    end
+end
+
+
 ---@param gam GameScene
 ---@param tile Tile
 ---@param rect Rect rectangle of the according tile
@@ -17,149 +111,47 @@ return function(gam, tile, rect, x, y, size)
     -- unit sizes
     local width_unit = size * 4
     local height_unit = size / 2
-
     local length_of_line = 50 - height_unit
 
-
     if gam.inspector == "macrobuilder" then
-        local player_character = WORLD.player_character
-
-        if player_character == nil then
-            return false
+        local result = macrobuilder(gam, tile, rect, x, y, size)
+        if result then
+            return result
         end
-
-        if player_character.realm ~= tile.province.realm then
-            return false
-        end
-
-        ---@type BuildingType
-        local building_type = gam.selected.macrobuilder_building_type
-
-        if building_type then
-
-            local best_location = nil
-
-            if building_type.tile_improvement then
-                local best_eff = 0
-                local province = tile.province
-                if province and building_type then
-                    for _, p_tile in pairs(province.tiles) do
-                        if not p_tile.tile_improvement then
-                            best_eff = math.max(best_eff, building_type.production_method:get_efficiency(p_tile))
-                            best_location = p_tile
-                        end
-                    end
-                end
-            end
-
-            local public_flag = false
-            local overseer = player_character
-            local funds = player_character.savings
-            local owner = player_character
-
-            if gam.macrobuilder_public_mode then
-                overseer = pv.overseer(tile.province.realm)
-                public_flag = true
-                funds = player_character.realm.budget.treasury
-                owner = nil
-            end
-
-            if not tile.province:can_build(9999, building_type, best_location, overseer, public_flag) then
-                return
-            end
-
-            local icon = building_type.icon
-            local name = building_type.name
-
-            local amount = 0
-            
-            for _, building in pairs(tile.province.buildings) do
-                if building.type == building_type then
-                    amount = amount + 1
-                end
-            end
-
-            local unit = size * 1.5
-
-            local rect = ui.rect(
-                x - unit / 2 ,
-                y - unit / 2,
-                unit,
-                unit
-            )
-
-            local construction_cost = ev.building_cost(
-                building_type,
-                overseer,
-                public_flag
-            )
-
-            local icon_rect = rect:subrect(0, 0, unit, unit, "left", 'up')
-            local count_rect = rect:subrect(0, unit, unit, unit / 2, "left", 'up')
-
-            if funds < construction_cost then
-                ut.icon_button(ASSETS.icons['cancel.png'], icon_rect, "Not possible to build", false)
-            elseif ut.icon_button(ASSETS.get_icon(icon), icon_rect, "Build " .. name .. " for " .. ut.to_fixed_point2(construction_cost) .. MONEY_SYMBOL ) then
-                ee.construct_building_with_payment(
-                    building_type,
-                    tile.province,
-                    best_location,
-                    owner,
-                    overseer,
-                    public_flag
-                )
-                
-                return true
-            end
-
-            ut.integer_entry("", amount, count_rect, "Current amount of buildings")
-        end
-
         return
     end
-    -- draw an icon on map
-    ui.image(ASSETS.get_icon('village.png'), rect)    
 
-    local name_rect = ui.rect(
-        x - size / 5, 
-        y - height_unit - 50, 
-        width_unit, 
-        height_unit
-    )
+    rect.x = x - size / 5
+    rect.y = y - length_of_line - height_unit * 2
+    rect.width = width_unit
+    rect.height = height_unit
+    ut.data_entry("", tile.province.name, rect)
 
-    local realm_rect = name_rect:copy()
-    realm_rect.y = realm_rect.y - height_unit
 
-    local population_rect = ui.rect(
-        x - size / 5, 
-        y - length_of_line - height_unit, 
-        width_unit,
-        height_unit
-    )
+    rect.y = rect.y - height_unit
+    local callback_coa = require "game.scenes.game.widgets.realm-name"(gam, tile.province.realm, height_unit, rect, 'callback')
 
-    local button_rect = ui.rect(
-        x - size / 5 + width_unit, 
-        y - 50 - height_unit * 2, 
-        size, 
-        size
-    )
+
+    rect.y = y - length_of_line - height_unit
+    local population = tile.province:population()
+    ut.data_entry("", tostring(population), rect)
 
     local line_rect = ui.rect(x - 1, y - length_of_line, 2, 50 - height_unit)
-
     ui.rectangle(line_rect)
 
-    if require "game.scenes.game.widgets.realm-name"(gam, tile.province.realm, height_unit, realm_rect) then
-        return true
+    if callback_coa then
+        return callback_coa
     end
 
-    ut.data_entry("", tile.province.name, name_rect)
-    local population = tile.province:population()
-    ut.data_entry("", tostring(population), population_rect)
-
     if WORLD.player_character then
+        local button_rect = ui.rect(
+            x - size / 5 + width_unit, 
+            y - 50 - height_unit * 2, 
+            size, 
+            size
+        )
         if ut.icon_button(ASSETS.get_icon("barbute.png"), button_rect) then
-            callback.toggle_raiding_target(gam, tile.province)()
-            return true
+            return callback.toggle_raiding_target(gam, tile.province)
         end
     end
 end

--- a/sote/game/scenes/game/widgets/realm-name.lua
+++ b/sote/game/scenes/game/widgets/realm-name.lua
@@ -5,18 +5,32 @@ local ut = require "game.ui-utils"
 ---@param realm Realm
 ---@param unit number
 ---@param rect Rect
-local function realm_name(gam, realm, unit, rect)
+---@param mode 'immediate'|'callback'|nil
+local function realm_name(gam, realm, unit, rect, mode)
+    if mode == nil then
+        mode = 'immediate'
+    end
 
     local COA_rect = rect:subrect(0, 0, unit, unit, "left", 'up')
-    if ut.coa(realm, COA_rect) then
-        print("Player COA Clicked")
+
+    local function press()
         gam.inspector = "realm"
         gam.selected.realm = realm
         ---@type Tile
         local captile = realm.capitol.center
         gam.click_tile(captile.tile_id)
+    end
 
-        return true
+    if ut.coa(realm, COA_rect) then
+        print("Player COA Clicked")
+        print(mode)
+
+        if mode == 'immediate' then
+            press()
+            return true
+        else
+            return press
+        end
     end
 
     local name_rect = rect:subrect(unit, 0, rect.width - unit, unit, "left", 'up')

--- a/sote/game/world-gen/resource-gen.lua
+++ b/sote/game/world-gen/resource-gen.lua
@@ -51,8 +51,14 @@ function ge.run()
 	-- Write resources back on tiles for faster querying
 	for _, province in pairs(WORLD.provinces) do
 		for _, tile in pairs(province.tiles) do
-			if tile.resource then
-				province.local_resources[tile.resource] = tile.resource
+			local resource = tile.resource
+			if resource then
+				province.local_resources[resource] = resource
+				table.insert(province.local_resources_location,
+					{
+						tile, resource
+					}
+				)
 			end
 		end
 	end


### PR DESCRIPTION
Sorting of labels should probably help with #47.
Added missed technology icon, which closes #95.
Macrobuilder icons are now shown from any distance, which closes #83
Border for location of the player should be visible again (was blocked by realm borders).