### PR TITLE
Adding Fullscreen Borderless Window and Resolution Changing to Options Menu

### DIFF
--- a/run-sote-linux.sh
+++ b/run-sote-linux.sh
@@ -1,1 +1,1 @@
-./sote/engine/bins/linux/love.AppImage sote
+./sote/engine/bins/linux/love.AppImage sote "$@"

--- a/sote/engine/ui.lua
+++ b/sote/engine/ui.lua
@@ -208,6 +208,7 @@ function Rect:copy()
 end
 
 ---Returns a new rect, using this rect as the new reference point.
+---@alias love.AlignMode "center"  | "left" | "right"
 ---@param x number
 ---@param y number
 ---@param width number

--- a/sote/engine/ui.lua
+++ b/sote/engine/ui.lua
@@ -135,8 +135,12 @@ end
 ---@param new_width number
 ---@param new_height number
 function ui.set_reference_screen_dimensions(new_width, new_height)
-	reference_width = new_width
-	reference_height = new_height
+	local current_ratio = reference_width / reference_height
+	local new_ratio = new_width / new_height
+	if current_ratio ~= new_ratio then
+		reference_width = reference_height * new_ratio
+	end
+	--print(reference_width / reference_height .. " " .. reference_width .. "x" .. reference_height)
 end
 
 ---Returns scaling factors that transform froms reference space to screen space that can be used with Love's draw functions.

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -3,23 +3,25 @@ local opt = {}
 
 ---@alias Fullscreen "false" | "exclusive" | "desktop"
 ---@class Options
----@feild ["volume"] number
----@feild ["fullscreen"] Fullscreen
----@feild ["fitscreen"] boolean
----@feild ["rotation"] boolean
----@feild ["update_map"] boolean
----@feild ["treasury_ledger"] number
----@feild ["debug_mode"] boolean
----@feild ["zoom_sensitivity"] number
----@feild ["camera_sensitivity"] number
----@feild ["exploration"] number
----@feild ["travel-start"] number
----@feild ["travel-end"] number
----@feild ["screen_resolution"] {width number, height number}
+---@field ["version"] string
+---@field ["volume"] number
+---@field ["fullscreen"] Fullscreen
+---@field ["fitscreen"] boolean
+---@field ["rotation"] boolean
+---@field ["update_map"] boolean
+---@field ["treasury_ledger"] number
+---@field ["debug_mode"] boolean
+---@field ["zoom_sensitivity"] number
+---@field ["camera_sensitivity"] number
+---@field ["exploration"] number
+---@field ["travel-start"] number
+---@field ["travel-end"] number
+---@field ["screen_resolution"] {width: number, height: number}
 
 ---@return Options
 function opt.init()
 	return {
+		["version"] = "v0.3.1",
 		["volume"] = 0,
 		["fullscreen"] = "false",
 		["fitscreen"] = true,
@@ -50,6 +52,11 @@ end
 function opt.verify()
 	local default = opt.init()
 
+	if OPTIONS.version ~= default.version then
+		OPTIONS = default
+		return
+	end
+	
 	for i, j in pairs(default) do
 		if OPTIONS[i] == nil then
 			OPTIONS[i] = j

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -7,7 +7,7 @@ local opt = {}
 function opt.init()
 	return {
 		["volume"] = 0,
-		["fullscreen"] = true,
+		["fullscreen"] ="normal",
 		["rotation"] = false,
 		["update_map"] = false,
 		["treasury_ledger"] = 120,

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -7,7 +7,7 @@ local opt = {}
 function opt.init()
 	return {
 		["volume"] = 0,
-		["fullscreen"] ="normal",
+		["fullscreen"] = FULLSCREEN.FALSE,
 		["rotation"] = false,
 		["update_map"] = false,
 		["treasury_ledger"] = 120,

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -17,6 +17,7 @@ function opt.init()
 		["exploration"] = 0,
 		["travel-start"] = 0,
 		["travel-end"] = 0,
+		["screen_resolution"] = {width = 1280, height = 720}
 	}
 end
 

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -5,6 +5,7 @@ local opt = {}
 ---@class Options
 ---@feild ["volume"] number
 ---@feild ["fullscreen"] Fullscreen
+---@feild ["fitscreen"] boolean
 ---@feild ["rotation"] boolean
 ---@feild ["update_map"] boolean
 ---@feild ["treasury_ledger"] number
@@ -21,6 +22,7 @@ function opt.init()
 	return {
 		["volume"] = 0,
 		["fullscreen"] = "false",
+		["fitscreen"] = true,
 		["rotation"] = false,
 		["update_map"] = false,
 		["treasury_ledger"] = 120,
@@ -57,22 +59,30 @@ end
 
 ---@param fullscreen Fullscreen
 function opt.updateFullscreen(fullscreen)
-	if OPTIONS == nil or OPTIONS.fullscreen == fullscreen then return end
+	if OPTIONS == nil then return end
 	---@class Options
 	OPTIONS = OPTIONS
+	local ui = require "engine.ui"
 	OPTIONS.fullscreen = fullscreen
 	if fullscreen == "false" then
 		love.window.setFullscreen(false)
 	else
 		love.window.setFullscreen(true, fullscreen)
 	end
-	if GAME_STATE.scene[1] == "game" then
+	local dim_x, dim_y = love.graphics.getDimensions()
+	if fullscreen ~= "false" and OPTIONS.fitscreen then
 		if fullscreen == "desktop" then
-			local dim_x, dim_y = love.graphics.getDimensions()
+			ui.set_reference_screen_dimensions(dim_x, dim_y)
+		else
+			ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width/dim_y,OPTIONS.screen_resolution.height/dim_x)
+		end
+	else
+		ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+	end
+	if GAME_STATE.scene[1] == "game" then
+		if fullscreen == "desktop" or (fullscreen == "exclusive" and OPTIONS.fitscreen) then
 			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(dim_x,dim_y)
 		else
-			local ui = require "engine.ui"
-			ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
 			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
 		end
 	end

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -1,5 +1,11 @@
 
 
+---@enum FULLSCREEN
+FULLSCREEN = {
+	FALSE = "false",
+	EXCLUSIVE = "exclusive",
+	DESKTOP = "desktop"
+}
 
 local opt = {}
 

--- a/sote/game/options.lua
+++ b/sote/game/options.lua
@@ -1,19 +1,26 @@
 
-
----@enum FULLSCREEN
-FULLSCREEN = {
-	FALSE = "false",
-	EXCLUSIVE = "exclusive",
-	DESKTOP = "desktop"
-}
-
 local opt = {}
 
+---@alias Fullscreen "false" | "exclusive" | "desktop"
+---@class Options
+---@feild ["volume"] number
+---@feild ["fullscreen"] Fullscreen
+---@feild ["rotation"] boolean
+---@feild ["update_map"] boolean
+---@feild ["treasury_ledger"] number
+---@feild ["debug_mode"] boolean
+---@feild ["zoom_sensitivity"] number
+---@feild ["camera_sensitivity"] number
+---@feild ["exploration"] number
+---@feild ["travel-start"] number
+---@feild ["travel-end"] number
+---@feild ["screen_resolution"] {width number, height number}
 
+---@return Options
 function opt.init()
 	return {
 		["volume"] = 0,
-		["fullscreen"] = FULLSCREEN.FALSE,
+		["fullscreen"] = "false",
 		["rotation"] = false,
 		["update_map"] = false,
 		["treasury_ledger"] = 120,
@@ -32,6 +39,7 @@ function opt.save()
 	bs.dumpLoveFile("options.bin", OPTIONS)
 end
 
+---@return Options
 function opt.load()
 	local bs = require "engine.bitser"
 	return bs.loadLoveFile("options.bin")
@@ -47,5 +55,28 @@ function opt.verify()
 	end
 end
 
+---@param fullscreen Fullscreen
+function opt.updateFullscreen(fullscreen)
+	if OPTIONS == nil or OPTIONS.fullscreen == fullscreen then return end
+	---@class Options
+	OPTIONS = OPTIONS
+	OPTIONS.fullscreen = fullscreen
+	if fullscreen == "false" then
+		love.window.setFullscreen(false)
+	else
+		love.window.setFullscreen(true, fullscreen)
+	end
+	if GAME_STATE.scene[1] == "game" then
+		if fullscreen == "desktop" then
+			local dim_x, dim_y = love.graphics.getDimensions()
+			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(dim_x,dim_y)
+		else
+			local ui = require "engine.ui"
+			ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+		end
+	end
+	require "game.ui-utils".reload_font()
+end
 
 return opt

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -71,12 +71,7 @@ function mm.draw()
 		elseif original == "exclusive" then OPTIONS.fullscreen = "desktop"
 		else OPTIONS.fullscreen = "normal" end
 	end
-	if original ~= OPTIONS.fullscreen then
-		-- if the status changed, update the fullscreen state...
-		if OPTIONS.fullscreen == "normal" then love.window.setFullscreen(false)
-		else love.window.setFullscreen(true, OPTIONS.fullscreen) end
-		require "game.ui-utils".reload_font()
-	end
+	if original ~= OPTIONS.fullscreen then love.updateFullscreen() end
 
 	--SCREEN RESOLUTION
 	local current_resolution=OPTIONS.screen_resolution.width .. 'x' .. tostring(OPTIONS.screen_resolution.height)
@@ -93,12 +88,12 @@ function mm.draw()
 				if name == current_resolution then active = true end
 				if ut.text_button(name, rect, nil, not active, active) then
 					OPTIONS.screen_resolution=modes[i]
-					if GAME_STATE.scene[1] == "game" then
-						GAME_STATE.scene[2].game_canvas=love.graphics.newCanvas(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
-					end
+					ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+					love.updateFullscreen()
 					love.window.updateMode(OPTIONS.screen_resolution.width, OPTIONS.screen_resolution.height, {
 						msaa = 2
 					})
+					require "game.ui-utils".reload_font()
 				end
 			end
 		end, UI_STYLE.scrollable_list_item_height, #modes, UI_STYLE.slider_width, resolution_scroll

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -71,7 +71,7 @@ function mm.draw()
 		elseif original == "exclusive" then OPTIONS.fullscreen = "desktop"
 		else OPTIONS.fullscreen = "normal" end
 	end
-	if original ~= OPTIONS.fullscreen then love.updateFullscreen() end
+	if original ~= OPTIONS.fullscreen then UpdateFullscreen() end
 
 	--SCREEN RESOLUTION
 	local current_resolution=OPTIONS.screen_resolution.width .. 'x' .. tostring(OPTIONS.screen_resolution.height)
@@ -89,7 +89,7 @@ function mm.draw()
 				if ut.text_button(name, rect, nil, not active, active) then
 					OPTIONS.screen_resolution=modes[i]
 					ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
-					love.updateFullscreen()
+					UpdateFullscreen()
 					love.window.updateMode(OPTIONS.screen_resolution.width, OPTIONS.screen_resolution.height, {
 						msaa = 2
 					})

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -58,14 +58,21 @@ function mm.draw()
 
 	-- FULLSCREEN
 	local original = OPTIONS.fullscreen
-	OPTIONS.fullscreen = ui.named_checkbox(
-		"Fullscreen",
-		layout:next(menu_button_width, menu_button_height), OPTIONS.fullscreen,
-		5
-	)
+	local fullscreen_text = "Windowed"
+	if original == "exclusive" then fullscreen_text = "Exclusive"
+	elseif original == "desktop" then fullscreen_text = "Desktop" end
+	if ut.text_button(
+		fullscreen_text,
+		layout:next(menu_button_width, menu_button_height)
+	) then
+		if original == "normal" then OPTIONS.fullscreen = "exclusive"
+		elseif original == "exclusive" then OPTIONS.fullscreen = "desktop"
+		else OPTIONS.fullscreen = "normal" end
+	end
 	if original ~= OPTIONS.fullscreen then
 		-- if the status changed, update the fullscreen state...
-		love.window.setFullscreen(OPTIONS.fullscreen)
+		if OPTIONS.fullscreen == "normal" then love.window.setFullscreen(false)
+		else love.window.setFullscreen(true, OPTIONS.fullscreen) end
 		require "game.ui-utils".reload_font()
 	end
 

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -3,6 +3,8 @@ local mm = {}
 local ui = require "engine.ui"
 local ut = require "game.ui-utils"
 
+local resolution_scroll = 0
+
 function mm.rect()
 	return ui.fullscreen():subrect(0, 20, 300, 600, "center", "center")
 end
@@ -75,6 +77,33 @@ function mm.draw()
 		else love.window.setFullscreen(true, OPTIONS.fullscreen) end
 		require "game.ui-utils".reload_font()
 	end
+
+	--SCREEN RESOLUTION
+	local current_resolution=OPTIONS.screen_resolution.width .. 'x' .. tostring(OPTIONS.screen_resolution.height)
+	local modes = love.window.getFullscreenModes()
+	table.sort(modes, function(a, b) return a.width*a.height < b.width*b.height end)
+	local box_size = layout:next(menu_button_width - UI_STYLE.slider_width, menu_button_height * 4.5)
+	box_size.x = box_size.x + UI_STYLE.slider_width/2
+	box_size.width = box_size.width - UI_STYLE.slider_width/4
+	resolution_scroll = ut.scrollview(
+		box_size, function(i, rect)
+			if i > 0 then
+				local name = modes[i].width .. 'x' .. modes[i].height
+				local active = false
+				if name == current_resolution then active = true end
+				if ut.text_button(name, rect, nil, not active, active) then
+					OPTIONS.screen_resolution=modes[i]
+					if GAME_STATE.scene[1] == "game" then
+						GAME_STATE.scene[2].game_canvas=love.graphics.newCanvas(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+					end
+					love.window.updateMode(OPTIONS.screen_resolution.width, OPTIONS.screen_resolution.height, {
+						msaa = 2
+					})
+				end
+			end
+		end, UI_STYLE.scrollable_list_item_height, #modes, UI_STYLE.slider_width, resolution_scroll
+	)
+
 
 	-- ROTATION
 	OPTIONS.rotation = ui.named_checkbox(

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -61,15 +61,15 @@ function mm.draw()
 	-- FULLSCREEN
 	local original = OPTIONS.fullscreen
 	local fullscreen_text = "Windowed"
-	if original == "exclusive" then fullscreen_text = "Exclusive"
-	elseif original == "desktop" then fullscreen_text = "Desktop" end
+	if original == FULLSCREEN.EXCLUSIVE then fullscreen_text = "Exclusive"
+	elseif original == FULLSCREEN.DESKTOP then fullscreen_text = "Desktop" end
 	if ut.text_button(
 		fullscreen_text,
 		layout:next(menu_button_width, menu_button_height)
 	) then
-		if original == "normal" then OPTIONS.fullscreen = "exclusive"
-		elseif original == "exclusive" then OPTIONS.fullscreen = "desktop"
-		else OPTIONS.fullscreen = "normal" end
+		if original == FULLSCREEN.FALSE then OPTIONS.fullscreen = FULLSCREEN.EXCLUSIVE
+		elseif original == FULLSCREEN.EXCLUSIVE then OPTIONS.fullscreen = FULLSCREEN.DESKTOP
+		else OPTIONS.fullscreen = FULLSCREEN.FALSE end
 	end
 	if original ~= OPTIONS.fullscreen then UpdateFullscreen() end
 

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -60,18 +60,19 @@ function mm.draw()
 
 	-- FULLSCREEN
 	local original = OPTIONS.fullscreen
+	local changed = OPTIONS.fullscreen
 	local fullscreen_text = "Windowed"
-	if original == FULLSCREEN.EXCLUSIVE then fullscreen_text = "Exclusive"
-	elseif original == FULLSCREEN.DESKTOP then fullscreen_text = "Desktop" end
+	if original == "exclusive" then fullscreen_text = "Exclusive"
+	elseif original == "desktop" then fullscreen_text = "Desktop" end
 	if ut.text_button(
 		fullscreen_text,
 		layout:next(menu_button_width, menu_button_height)
 	) then
-		if original == FULLSCREEN.FALSE then OPTIONS.fullscreen = FULLSCREEN.EXCLUSIVE
-		elseif original == FULLSCREEN.EXCLUSIVE then OPTIONS.fullscreen = FULLSCREEN.DESKTOP
-		else OPTIONS.fullscreen = FULLSCREEN.FALSE end
+		if original == "false" then changed = "exclusive"
+		elseif original == "exclusive" then changed = "desktop"
+		else changed = "false" end
 	end
-	if original ~= OPTIONS.fullscreen then UpdateFullscreen() end
+	if original ~= changed then require "game.options".updateFullscreen(changed) end
 
 	--SCREEN RESOLUTION
 	local current_resolution=OPTIONS.screen_resolution.width .. 'x' .. tostring(OPTIONS.screen_resolution.height)
@@ -89,7 +90,7 @@ function mm.draw()
 				if ut.text_button(name, rect, nil, not active, active) then
 					OPTIONS.screen_resolution=modes[i]
 					ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
-					UpdateFullscreen()
+					require "game.options".updateFullscreen(OPTIONS.fullscreen)
 					love.window.updateMode(OPTIONS.screen_resolution.width, OPTIONS.screen_resolution.height, {
 						msaa = 2
 					})

--- a/sote/game/scenes/main-menu/options.lua
+++ b/sote/game/scenes/main-menu/options.lua
@@ -74,11 +74,22 @@ function mm.draw()
 	end
 	if original ~= changed then require "game.options".updateFullscreen(changed) end
 
+	local stretch = OPTIONS.fitscreen
+	OPTIONS.fitscreen = ui.named_checkbox(
+		"Use monitor aspect for Fullscreen",
+		layout:next(menu_button_width, menu_button_height), OPTIONS.fitscreen,
+		5
+	)
+	if stretch ~= OPTIONS.fitscreen then
+		require "game.options".updateFullscreen(OPTIONS.fullscreen)
+	end
+
+
 	--SCREEN RESOLUTION
 	local current_resolution=OPTIONS.screen_resolution.width .. 'x' .. tostring(OPTIONS.screen_resolution.height)
 	local modes = love.window.getFullscreenModes()
 	table.sort(modes, function(a, b) return a.width*a.height < b.width*b.height end)
-	local box_size = layout:next(menu_button_width - UI_STYLE.slider_width, menu_button_height * 4.5)
+	local box_size = layout:next(menu_button_width - UI_STYLE.slider_width, menu_button_height * 3)
 	box_size.x = box_size.x + UI_STYLE.slider_width/2
 	box_size.width = box_size.width - UI_STYLE.slider_width/4
 	resolution_scroll = ut.scrollview(

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -241,7 +241,13 @@ function love.keypressed(key)
 		input_counter = input_counter + 1
 		print("the game is responsive: " .. tostring(input_counter))
 	elseif key == "f4" then
-		love.window.setFullscreen(not love.window.getFullscreen())
+		if OPTIONS.fullscreen == "normal" then
+			OPTIONS.fullscreen = "exclusive"
+			love.updateFullscreen()
+		else
+			OPTIONS.fullscreen = "normal"
+			love.updateFullscreen()
+		end
 		reload_font()
 	end
 
@@ -266,4 +272,22 @@ end
 
 function love.wheelmoved(x, y)
 	ui.on_wheelmoved(x, y)
+end
+
+function love.updateFullscreen()
+	if OPTIONS.fullscreen == "normal" then
+		love.window.setFullscreen(false)
+	else
+		love.window.setFullscreen(true, OPTIONS.fullscreen)
+	end
+	if GAME_STATE.scene[1] == "game" then
+		if OPTIONS.fullscreen == "desktop" then
+			local dim_x, dim_y = love.graphics.getDimensions()
+			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(dim_x,dim_y)
+		else
+			ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
+		end
+	end
+	require "game.ui-utils".reload_font()
 end

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -3,6 +3,13 @@ print(love.math.random(100))
 local tab = require "engine.table"
 local ui = require "engine.ui"
 
+---@enum FULLSCREEN
+FULLSCREEN = {
+	FALSE = "false",
+	EXCLUSIVE = "exclusive",
+	DESKTOP = "desktop"
+}
+
 -- Reloads the font used for rendering
 local reload_font = require "game.ui-utils".reload_font
 
@@ -241,10 +248,10 @@ function love.keypressed(key)
 		input_counter = input_counter + 1
 		print("the game is responsive: " .. tostring(input_counter))
 	elseif key == "f4" then
-		if OPTIONS.fullscreen == "normal" then
-			OPTIONS.fullscreen = "exclusive"
+		if OPTIONS.fullscreen == FULLSCREEN.FALSE then
+			OPTIONS.fullscreen = FULLSCREEN.EXCLUSIVE
 		else
-			OPTIONS.fullscreen = "normal"
+			OPTIONS.fullscreen = FULLSCREEN.FALSE
 		end
 		UpdateFullscreen()
 	end
@@ -273,13 +280,13 @@ function love.wheelmoved(x, y)
 end
 
 function UpdateFullscreen()
-	if OPTIONS.fullscreen == "normal" then
+	if OPTIONS.fullscreen == FULLSCREEN.FALSE then
 		love.window.setFullscreen(false)
 	else
 		love.window.setFullscreen(true, OPTIONS.fullscreen)
 	end
 	if GAME_STATE.scene[1] == "game" then
-		if OPTIONS.fullscreen == "desktop" then
+		if OPTIONS.fullscreen == FULLSCREEN.DESKTOP then
 			local dim_x, dim_y = love.graphics.getDimensions()
 			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(dim_x,dim_y)
 		else

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -238,10 +238,10 @@ function love.keypressed(key)
 		print("the game is responsive: " .. tostring(input_counter))
 	elseif key == "f4" then
 		if OPTIONS.fullscreen == "false" then
-			require "game.ui".updateFullscreen("exclusive")
+			require "game.options".updateFullscreen("exclusive")
 		else
 			OPTIONS.fullscreen = "false"
-			require "game.ui".updateFullscreen("false")
+			require "game.options".updateFullscreen("false")
 		end
 	end
 

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -181,10 +181,9 @@ Possible command line arguments:
 		msaa = 2
 	})
 	if tab.contains(args, "--windowed") then
-		OPTIONS.fullscreen = FULLSCREEN.FLASE
-		love.window.setFullscreen(false)
+		require "game.options".setFullscreen("false")
 	else
-		if OPTIONS.fullscreen ~= FULLSCREEN.FALSE then
+		if OPTIONS.fullscreen ~= "false" then
 			love.window.setFullscreen(true, OPTIONS.fullscreen)
 		else
 			love.window.setFullscreen(false)
@@ -238,12 +237,12 @@ function love.keypressed(key)
 		input_counter = input_counter + 1
 		print("the game is responsive: " .. tostring(input_counter))
 	elseif key == "f4" then
-		if OPTIONS.fullscreen == FULLSCREEN.FALSE then
-			OPTIONS.fullscreen = FULLSCREEN.EXCLUSIVE
+		if OPTIONS.fullscreen == "false" then
+			OPTIONS.updateFullscreen("exclusive")
 		else
-			OPTIONS.fullscreen = FULLSCREEN.FALSE
+			OPTIONS.fullscreen = "false"
+			OPTIONS.updateFullscreen("false")
 		end
-		UpdateFullscreen()
 	end
 
 	ui.on_keypressed(key)
@@ -267,22 +266,4 @@ end
 
 function love.wheelmoved(x, y)
 	ui.on_wheelmoved(x, y)
-end
-
-function UpdateFullscreen()
-	if OPTIONS.fullscreen == FULLSCREEN.FALSE then
-		love.window.setFullscreen(false)
-	else
-		love.window.setFullscreen(true, OPTIONS.fullscreen)
-	end
-	if GAME_STATE.scene[1] == "game" then
-		if OPTIONS.fullscreen == FULLSCREEN.DESKTOP then
-			local dim_x, dim_y = love.graphics.getDimensions()
-			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(dim_x,dim_y)
-		else
-			ui.set_reference_screen_dimensions(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
-			GAME_STATE.scene[2].game_canvas = love.graphics.newCanvas(OPTIONS.screen_resolution.width,OPTIONS.screen_resolution.height)
-		end
-	end
-	require "game.ui-utils".reload_font()
 end

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -183,11 +183,11 @@ Possible command line arguments:
 	print(OPTIONS.fullscreen)
 	if tab.contains(args, "--windowed") then
 		print("HAS WINDOW ARG")
-		OPTIONS.fullscreen = "normal"
+		OPTIONS.fullscreen = FULLSCREEN.FLASE
 		print(OPTIONS.fullscreen)
 		love.window.setFullscreen(false)
 	else
-		if OPTIONS.fullscreen ~= "normal" then
+		if OPTIONS.fullscreen ~= FULLSCREEN.FALSE then
 			love.window.setFullscreen(true, OPTIONS.fullscreen)
 		else
 			love.window.setFullscreen(false)

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -243,12 +243,10 @@ function love.keypressed(key)
 	elseif key == "f4" then
 		if OPTIONS.fullscreen == "normal" then
 			OPTIONS.fullscreen = "exclusive"
-			love.updateFullscreen()
 		else
 			OPTIONS.fullscreen = "normal"
-			love.updateFullscreen()
 		end
-		reload_font()
+		UpdateFullscreen()
 	end
 
 	ui.on_keypressed(key)
@@ -274,7 +272,7 @@ function love.wheelmoved(x, y)
 	ui.on_wheelmoved(x, y)
 end
 
-function love.updateFullscreen()
+function UpdateFullscreen()
 	if OPTIONS.fullscreen == "normal" then
 		love.window.setFullscreen(false)
 	else

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -3,13 +3,6 @@ print(love.math.random(100))
 local tab = require "engine.table"
 local ui = require "engine.ui"
 
----@enum FULLSCREEN
-FULLSCREEN = {
-	FALSE = "false",
-	EXCLUSIVE = "exclusive",
-	DESKTOP = "desktop"
-}
-
 -- Reloads the font used for rendering
 local reload_font = require "game.ui-utils".reload_font
 

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -180,11 +180,8 @@ Possible command line arguments:
 	love.window.updateMode(OPTIONS.screen_resolution.width, OPTIONS.screen_resolution.height, {
 		msaa = 2
 	})
-	print(OPTIONS.fullscreen)
 	if tab.contains(args, "--windowed") then
-		print("HAS WINDOW ARG")
 		OPTIONS.fullscreen = FULLSCREEN.FLASE
-		print(OPTIONS.fullscreen)
 		love.window.setFullscreen(false)
 	else
 		if OPTIONS.fullscreen ~= FULLSCREEN.FALSE then

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -238,10 +238,10 @@ function love.keypressed(key)
 		print("the game is responsive: " .. tostring(input_counter))
 	elseif key == "f4" then
 		if OPTIONS.fullscreen == "false" then
-			OPTIONS.updateFullscreen("exclusive")
+			require "game.ui".updateFullscreen("exclusive")
 		else
 			OPTIONS.fullscreen = "false"
-			OPTIONS.updateFullscreen("false")
+			require "game.ui".updateFullscreen("false")
 		end
 	end
 

--- a/sote/main.lua
+++ b/sote/main.lua
@@ -177,15 +177,18 @@ Possible command line arguments:
 		require "game.options".verify()
 	end
 
-	love.window.updateMode(800, 600, {
+	love.window.updateMode(OPTIONS.screen_resolution.width, OPTIONS.screen_resolution.height, {
 		msaa = 2
 	})
-
+	print(OPTIONS.fullscreen)
 	if tab.contains(args, "--windowed") then
+		print("HAS WINDOW ARG")
+		OPTIONS.fullscreen = "normal"
+		print(OPTIONS.fullscreen)
 		love.window.setFullscreen(false)
 	else
-		if OPTIONS.fullscreen then
-			love.window.setFullscreen(true)
+		if OPTIONS.fullscreen ~= "normal" then
+			love.window.setFullscreen(true, OPTIONS.fullscreen)
 		else
 			love.window.setFullscreen(false)
 		end


### PR DESCRIPTION
#141
The following code changes the options menu to include a scroll view of resolutions fetched by the love2d engine and a replacement of the fullscreen checkbox with a cycling button to move between windowed, fullscreen (exclusive), and borderless fullscreen window (desktop).

In order to achieve this the following changes were made:

- `OPTIONS.fullscreen` is now a string that hold either `"normal"`, `"fullscreen"`, or `"desktop"`
- `OPTIONS` now contains a `"screen_resolution"` that holds a `width` and `height` that hold the desired screen resolution
- The fullscreen option was changed from a checkbox to a button that cycles through the three settings.
- A scrolllview of buttons containing possible screen resolutions was added bellow the fullscreen option.
- Changed to `set_reference_screen_dimensions` function to keep reference fixed and allow width to stretch or shrink to fit view.
- Added an `updateFullscreen` function to handle updating window and canvas updates on options change.

Windowed with a resolution of 800x600 (1280x720 image)
![Screenshot from 2024-02-06 20-16-33](https://github.com/Calandiel/SongsOfGPL/assets/158529472/4d14c43e-2e03-4a92-81a4-21de0ddf4687)

Fullscreen (exclusive) actually changes the monitor resolution, screenshot is at size of settings value but the monitor will stretch it as one would expect for mismatched aspect ratios.
![Screenshot from 2024-02-06 20-12-20](https://github.com/Calandiel/SongsOfGPL/assets/158529472/e2f809e9-87ec-4112-955c-6dacf8f78d5c)
Borderless Fullscreen Window (desktop) is much sharper than exclusive (unintentional) but still catches the mismatched aspect ratio (intentional).
![Screenshot from 2024-02-06 20-12-42](https://github.com/Calandiel/SongsOfGPL/assets/158529472/59e9ac94-25b9-4943-a85f-e383309df891)

It works well except for 4:3 resolutions where the market can stretch off the edge of the screen.