### PR TITLE
Generalizing the character-list widget for tables and adding a table filter utility function

### DIFF
--- a/sote/engine/table.lua
+++ b/sote/engine/table.lua
@@ -143,7 +143,7 @@ function tab.random_select_from_set(items)
 	return k, v
 end
 
----Given a table and a function with parameter of table falue that resolves to a boolean,
+---Given a table and a function with parameter of table value type that resolves to a boolean,
 ---return a new table with all values that resolve to true
 ---@generic K, V
 ---@param items table<K, V>

--- a/sote/engine/table.lua
+++ b/sote/engine/table.lua
@@ -143,4 +143,20 @@ function tab.random_select_from_set(items)
 	return k, v
 end
 
+---Given a table and a function with parameter of table falue that resolves to a boolean,
+---return a new table with all values that resolve to true
+---@generic K, V
+---@param items table<K, V>
+---@param filter fun(a: V):boolean
+---@return table<K, V>
+function tab.filter(items, filter)
+	local r = {}
+	for k,v in pairs(items) do
+		if filter(v) then
+			r[k] = v
+		end
+	end
+	return r
+end
+
 return tab

--- a/sote/engine/ui.lua
+++ b/sote/engine/ui.lua
@@ -1,5 +1,7 @@
 local ui = {}
 
+---@alias love.AlignMode "center" | "left" | "right"
+
 -- #######################
 -- ### DEFAULT STYLING ###
 -- #######################

--- a/sote/game/scenes/game/inspector-character.lua
+++ b/sote/game/scenes/game/inspector-character.lua
@@ -231,7 +231,7 @@ function window.draw(game)
     end
 
     if province and province_visible then
-        local response = characters_list_widget(characters_list, character.province, true)()
+        local response = characters_list_widget(characters_list, character.province.characters, "Local Characters", true)()
         if response then
             game.selected.character = response
         end

--- a/sote/game/scenes/game/tile-inspector.lua
+++ b/sote/game/scenes/game/tile-inspector.lua
@@ -1030,7 +1030,7 @@ function re.draw(gam)
 					},
 					{
 						text = "Home",
-						tooltip = "All characters in the province.",
+						tooltip = "Characters that are at home.",
 						closure = function ()
 							local response = require "game.scenes.game.widgets.character-list"(
 								tab_content,

--- a/sote/game/scenes/game/tile-inspector.lua
+++ b/sote/game/scenes/game/tile-inspector.lua
@@ -1005,7 +1005,8 @@ function re.draw(gam)
 			closure = function()
 				local response = require "game.scenes.game.widgets.character-list"(
 					tab_content,
-					tile.province
+					tile.province.characters,
+					"Local Characters"
 				)()
 				if response then
 					gam.selected.character = response

--- a/sote/game/scenes/game/widgets/character-list.lua
+++ b/sote/game/scenes/game/widgets/character-list.lua
@@ -48,9 +48,10 @@ local function pop_sex(pop)
 end
 
 ---@param rect Rect
----@param province Province
+---@param table table<POP, POP>
+---@param title string?
 ---@param compact boolean?
-return function(rect, province, compact)
+return function(rect, table, title, compact)
     if compact == nil then
         compact = false
     end
@@ -110,10 +111,13 @@ return function(rect, province, compact)
             }
         }
         init_state(compact)
-
-        local top = rect:subrect(0, 0, rect.width, UI_STYLE.table_header_height, "left", "up")
-        local bottom = rect:subrect(0, UI_STYLE.table_header_height, rect.width, rect.height - UI_STYLE.table_header_height, "left", "up")
-        ui.centered_text("Local characters", top)
-        return ut.table(bottom, province.characters, columns, state)
+        local bottom_height = rect.height
+        if title then
+            bottom_height = bottom_height - UI_STYLE.table_header_height
+            local top = rect:subrect(0, 0, rect.width, UI_STYLE.table_header_height, "left", "up")
+            ui.centered_text(title, top)
+        end
+        local bottom = rect:subrect(0, UI_STYLE.table_header_height, rect.width, bottom_height, "left", "up")
+        return ut.table(bottom, table, columns, state)
     end
 end

--- a/sote/game/scenes/game/widgets/character-list.lua
+++ b/sote/game/scenes/game/widgets/character-list.lua
@@ -112,12 +112,14 @@ return function(rect, table, title, compact)
         }
         init_state(compact)
         local bottom_height = rect.height
+        local bottom_y = 0
         if title then
             bottom_height = bottom_height - UI_STYLE.table_header_height
+            bottom_y = UI_STYLE.table_header_height
             local top = rect:subrect(0, 0, rect.width, UI_STYLE.table_header_height, "left", "up")
             ui.centered_text(title, top)
         end
-        local bottom = rect:subrect(0, UI_STYLE.table_header_height, rect.width, bottom_height, "left", "up")
+        local bottom = rect:subrect(0, bottom_y, rect.width, bottom_height, "left", "up")
         return ut.table(bottom, table, columns, state)
     end
 end


### PR DESCRIPTION
This code changes the character-list widget to operate on a table on pops and gives it an optional string parameter that will adjust the bottom size to make room for it, if present. To go with this, it includes a simple filter function in _engine.table_ that will take a table and a boolean returning function and return a new table of values that evaluate to true.
The code also include examples to the changes in how it can easily retain the previous behaviors (in the character inspector) while being easily adaptable to any list of characters the UI needs to display (in the tile-inspector).

Preserving original behavior (just add title string as parameter):
![Screenshot from 2024-02-11 14-35-57](https://github.com/Calandiel/SongsOfGPL/assets/158529472/a527bb28-98d3-48ea-9a76-e0d379be112c)
With no optional parameters:
![Screenshot from 2024-02-11 14-36-06](https://github.com/Calandiel/SongsOfGPL/assets/158529472/e599ebb0-d085-4a0f-8e66-e5b6718a0b0d)
Applying the filter function:
![Screenshot from 2024-02-11 14-36-11](https://github.com/Calandiel/SongsOfGPL/assets/158529472/650ef15c-cfba-4411-8354-6b2c6a300c22)
![Screenshot from 2024-02-11 14-36-15](https://github.com/Calandiel/SongsOfGPL/assets/158529472/5b556cf5-1f95-4ea3-bbe0-e45fc0ec4ac1)
