### PR TITLE
Lua Language Server Warning Cleanup

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,5 +2,7 @@
     "runtime.version": "Lua 5.2",
     "diagnostics.disable": [
         "redundant-parameter"
-    ]
+    ],
+    "diagnostics.ignoredFiles": "Disable",
+    "diagnostics.globals": ["love","jit"]
   }

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,3 @@
+{
+    "runtime.version": "Lua 5.2"
+  }

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,6 @@
 {
-    "runtime.version": "Lua 5.2"
+    "runtime.version": "Lua 5.2",
+    "diagnostics.disable": [
+        "redundant-parameter"
+    ]
   }

--- a/sote/engine/love-alias.lua
+++ b/sote/engine/love-alias.lua
@@ -21,6 +21,6 @@
 ---@class love.ImageData
 ---@field encode fun(self: love.ImageData, foramt: ImageEncodingFormat, fielname: string?): FileData
 
-
----@alias love.Source.stop fun():boolean
----@alias love.Source.play fun():boolean
+---@class love.Source
+---@field stop fun():boolean
+---@field play fun():boolean

--- a/sote/engine/love-alias.lua
+++ b/sote/engine/love-alias.lua
@@ -1,0 +1,25 @@
+---@alias love.KeyConstant characterKeys | symbolKeys | numpadKeys | navigationKeys | editingKeys | functionKeys | modifierKeys | applicationKeys | miscKeys
+---@alias characterKeys "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z" | "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+---@alias symbolKeys "!" | "\"" | "#" | "$" | "&" | "\'" | "(" | ")" | "*" | "+" | "," | "-" | "." | "/" | ":" | ";" | "<" | "=" | ">" | "?" | "@" | "\[" | "\\" | "\]" | "^" | "_" | "`"
+---@alias numpadKeys "kp0" | "kp1" | "kp2" | "kp3" | "kp4" | "kp5" | "kp6" | "kp7" | "kp8" | "kp9" | "kp." | "kp," | "kp/" | "kp*" | "kp+" | "kpenter" | "kp="
+---@alias navigationKeys "up" | "down" | "right" | "left" | "home" | "end" | "pageup" | "pagedown"
+---@alias editingKeys "insert" | "backspace" | "tab" | "clear" | "return" | "delete"
+---@alias functionKeys "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12" | "f13" | "f14" | "f15" | "f16" | "f17" | "f18"
+---@alias applicationKeys "www" | "mail" | "calculator" | "computer" | "appsearch" | "apphome" | "appback" | "appforward" | "apprefresh" | "appbookmarks"
+---@alias modifierKeys "numlock" | "capslock" | "scrolllock" | "rshift" | "lshift" | "rctrl" | "lctrl" | "ralt" | "lalt" | "rgui" | "lgui" | "mode"
+---@alias miscKeys "pause" | "escape" | "help" | "printscreen" | "sysreq" | "menu" | "application" | "power" | "currencyunit" | "undo"
+
+---@class love.Image
+---@field getWidth fun():number
+---@field getHeight fun():number
+
+
+---@class FileData
+
+---@alias ImageEncodingFormat "tga" | "png" | "exr" | "jpg" | "bmp"
+---@class love.ImageData
+---@field encode fun(self: love.ImageData, foramt: ImageEncodingFormat, fielname: string?): FileData
+
+
+---@alias love.Source.stop fun():boolean
+---@alias love.Source.play fun():boolean

--- a/sote/engine/love-alias.lua
+++ b/sote/engine/love-alias.lua
@@ -9,10 +9,11 @@
 ---@alias modifierKeys "numlock" | "capslock" | "scrolllock" | "rshift" | "lshift" | "rctrl" | "lctrl" | "ralt" | "lalt" | "rgui" | "lgui" | "mode"
 ---@alias miscKeys "pause" | "escape" | "help" | "printscreen" | "sysreq" | "menu" | "application" | "power" | "currencyunit" | "undo"
 
+---@alias love.AlignMode "center"  | "left" | "right"
+
 ---@class love.Image
 ---@field getWidth fun():number
 ---@field getHeight fun():number
-
 
 ---@class FileData
 

--- a/sote/engine/ui.lua
+++ b/sote/engine/ui.lua
@@ -208,7 +208,6 @@ function Rect:copy()
 end
 
 ---Returns a new rect, using this rect as the new reference point.
----@alias love.AlignMode "center"  | "left" | "right"
 ---@param x number
 ---@param y number
 ---@param width number

--- a/sote/game/entities/world.lua
+++ b/sote/game/entities/world.lua
@@ -532,8 +532,10 @@ function world.World:tick()
 				for _, target in pairs(realm.reward_flags) do
 					local warbands = realm.raiders_preparing[target]
 					local units = 0
-					for _, warband in pairs(warbands) do
-						units = units + warband:size()
+					if warbands ~= nil then
+						for _, warband in pairs(warbands) do
+							units = units + warband:size()
+						end
 					end
 
 					-- with some probability, launch the raid

--- a/sote/game/entities/world.lua
+++ b/sote/game/entities/world.lua
@@ -223,7 +223,7 @@ end
 ---Schedules an event immediately
 ---@param event string
 ---@param root Character
----@param associated_data table
+---@param associated_data table?
 function world.World:emit_immediate_event(event, root, associated_data)
 	if root == nil then
 		error("Attempt to call event for nil root")

--- a/sote/game/raws/decisions/character-decisions.lua
+++ b/sote/game/raws/decisions/character-decisions.lua
@@ -259,10 +259,14 @@ local function load()
 			local realm = root.province.realm
 			local province = root.province
 			local warband = root.leading_warband
-			if office_triggers.guard_leader(root, root.province.realm) then
-				warband = realm.capitol_guard
-			end
-			realm:add_patrol(province, warband)
+			if realm ~= nil then
+				if office_triggers.guard_leader(root, root.province.realm) then
+					warband = realm.capitol_guard
+				end
+				if warband then
+					realm:add_patrol(province, warband)
+				else error("Character is not leading a warband!") end
+			else error("Character has no realm!") end
 		end
 	}
 

--- a/sote/game/raws/decisions/interpersonal.lua
+++ b/sote/game/raws/decisions/interpersonal.lua
@@ -135,7 +135,7 @@ local function load()
 		end,
 		effect = function(root, primary_target, secondary_target)
 			ie.set_successor(root, primary_target)
-            WORLD:emit_immediate_event('succession-set', primary_target, root, nil)
+            WORLD:emit_immediate_event('succession-set', primary_target, root)
 		end
 	}
 end

--- a/sote/game/raws/events/travel.lua
+++ b/sote/game/raws/events/travel.lua
@@ -66,8 +66,8 @@ local function load()
                     local party = root.leading_warband
                     party.status = "travelling"
                     if party ~= nil then
-                    party:consume_supplies(associated_data.travel_time)
-                    WORLD:emit_action("travel", root, associated_data.destination, associated_data.travel_time, true)
+                        party:consume_supplies(associated_data.travel_time)
+                        WORLD:emit_action("travel", root, associated_data.destination, associated_data.travel_time, true)
                     else error("Character is traveling without a warband!") end
                 end,
                 viable =function ()

--- a/sote/game/raws/events/travel.lua
+++ b/sote/game/raws/events/travel.lua
@@ -20,9 +20,11 @@ local function load()
             associated_data = associated_data
 
             local party = root.leading_warband
-            party.status = "travelling"
-            party:consume_supplies(associated_data.travel_time)
-            WORLD:emit_action("travel", root, associated_data.destination, associated_data.travel_time, true)
+            if party ~= nil then
+                party.status = "travelling"
+                party:consume_supplies(associated_data.travel_time)
+                WORLD:emit_action("travel", root, associated_data.destination, associated_data.travel_time, true)
+            else error("Character trying to travel without a warband!") end
         end
     }
 
@@ -63,8 +65,10 @@ local function load()
                 outcome = function ()
                     local party = root.leading_warband
                     party.status = "travelling"
+                    if party ~= nil then
                     party:consume_supplies(associated_data.travel_time)
                     WORLD:emit_action("travel", root, associated_data.destination, associated_data.travel_time, true)
+                    else error("Character is traveling without a warband!") end
                 end,
                 viable =function ()
                     return true

--- a/sote/game/scenes/game.lua
+++ b/sote/game/scenes/game.lua
@@ -1,4 +1,5 @@
 ---@class GameScene
+---@field tile_inspector_tab TileInspectorTab
 local gam = {}
 
 require "game.scenes.global-style"

--- a/sote/game/scenes/game/tile-inspector.lua
+++ b/sote/game/scenes/game/tile-inspector.lua
@@ -970,9 +970,10 @@ function re.draw(gam)
 	panel.height = panel.height - unit
 
 	local tab_content = panel:subrect(0, unit, panel.width, panel.height - unit, "left", "up")
-
+	
 	gam.tile_inspector_tab = gam.tile_inspector_tab or "GEN"
-
+	
+	---@alias TileInspectorTab "GEN" | "BLD" | "TEC" | "CHR" | "DCS" | "GEO"
 	local tabs = {
 		{
 			text = "GEN",

--- a/sote/game/scenes/game/tile-inspector.lua
+++ b/sote/game/scenes/game/tile-inspector.lua
@@ -970,9 +970,9 @@ function re.draw(gam)
 	panel.height = panel.height - unit
 
 	local tab_content = panel:subrect(0, unit, panel.width, panel.height - unit, "left", "up")
-	
+
 	gam.tile_inspector_tab = gam.tile_inspector_tab or "GEN"
-	
+
 	---@alias TileInspectorTab "GEN" | "BLD" | "TEC" | "CHR" | "DCS" | "GEO"
 	local tabs = {
 		{


### PR DESCRIPTION
This PR somewhat covers #139

I have reduced a majority of the warnings emitted by the language server by adding the files _love-alias.lua_ that hold aliases and minimal class definitions, and  _.luarc.json_ that defines the lua version as 5.2 (if that's what it really is, it happens to clean up the most warnings).
I also added `"Lua.diagnostics.globals": ["love","jit"]` to _settings.json_ in `.vscode` to further eliminate warnings, although this is not tracked.

These changes dropped the number of warnings near the single digit range and I was easily able add some nil guards, find an extraneous parameter in a function call and make the `emit_immediate_event` parameter `associate_data` be nil-able.

There are still a few warnings that I don't know if or how they should be fixed.

The first is in _lovebird.lua_ that needs a nil guard in `lovebird.unescape(str)` for if `tonumber` returns a `nil` and the other is to remove/ignore the `loadstring` call since its depreciated in 5.2; but I don't know if this file should be changed or just have the language server ignore it.

The second is a possible error in _tile-inspector.lua_.
https://github.com/Calandiel/SongsOfGPL/blob/d708205a7c02af118e7e7a26f0fd72ff2f9fde47/sote/game/scenes/game/tile-inspector.lua#L1101
The language server calls it an undefined global but this is at the end of the function `re.old_draw` which is never called. This could probably moved to another file and ignored or removed altogether.