### PR TITLE
Fixed set_home to set instead of clear and grant_noblitity to cull pop tier parent-child relationships

### DIFF
--- a/sote/engine/table.lua
+++ b/sote/engine/table.lua
@@ -159,4 +159,19 @@ function tab.filter(items, filter)
 	return r
 end
 
+---Given a table, an accumulable of any type, and an accumulator function with parameter the accumulable type,
+---and the table's key and value types that return an accumulable type, apply the function on each key value pair
+---and return the accumulable.
+---@generic A, K, V
+---@param items table<K, V>
+---@param accumulable A
+---@param accumulator fun(a: A, k: K, v: V):A
+---@return table<K, V>
+function tab.accumulate(items, accumulable, accumulator)
+	for k,v in pairs(items) do
+		accumulator(accumulable, k, v)
+	end
+	return accumulable
+end
+
 return tab

--- a/sote/game/entities/province.lua
+++ b/sote/game/entities/province.lua
@@ -267,7 +267,7 @@ end
 function prov.Province:set_home(pop)
 	-- print('SET HOME', pop.name)
 
-	self:set_home_pop_nil_wrapper(pop)
+	self.home_to[pop] = pop
 	pop.home_province = self
 	pop.realm = self.realm
 end

--- a/sote/game/raws/effects/political.lua
+++ b/sote/game/raws/effects/political.lua
@@ -357,7 +357,7 @@ end
 ---@param reason POLITICAL_REASON
 ---@return Character?
 function PoliticalEffects.grant_nobility_to_random_pop(province, reason)
-	local pop = tabb.random_select_from_set(tabb.filter(province.home_to,function(a)return not a:is_character() end))
+	local pop = tabb.random_select_from_set(province.all_pops)
 
 	if pop then
 		PoliticalEffects.grant_nobility(pop, province, reason)

--- a/sote/game/raws/effects/political.lua
+++ b/sote/game/raws/effects/political.lua
@@ -318,6 +318,17 @@ function PoliticalEffects.grant_nobility(pop, province, reason)
 			.. "\n pop.province.name = "
 			.. pop.province.name)
 	end
+
+	-- break parent-child link with pops
+	if pop.parent then
+		pop.parent.children[pop] = nil
+		pop.parent = nil
+	end
+	for _,v in pairs(pop.children) do
+		pop.children[v].parent = nil
+		pop.children[v] = nil
+	end
+
 	province:fire_pop(pop)
 	pop:unregister_military()
 	province.all_pops[pop] = nil
@@ -346,7 +357,7 @@ end
 ---@param reason POLITICAL_REASON
 ---@return Character?
 function PoliticalEffects.grant_nobility_to_random_pop(province, reason)
-	local pop = tabb.random_select_from_set(province.all_pops)
+	local pop = tabb.random_select_from_set(tabb.filter(province.home_to,function(a)return not a:is_character() end))
 
 	if pop then
 		PoliticalEffects.grant_nobility(pop, province, reason)

--- a/sote/game/raws/events/succession.lua
+++ b/sote/game/raws/events/succession.lua
@@ -36,17 +36,18 @@ local function load()
                         else
                             ---@type Character?
                             local final_successor = nil
+                            -- try to find a local noble
                             for _, pretender in pairs(capitol.characters) do
-                                if
-                                    final_successor == nil
-                                    and pretender ~= character
-                                then
-                                    final_successor = pretender
-                                elseif
-                                    pv.popularity(pretender, realm) > pv.popularity(final_successor, realm)
-                                    and pretender ~= character
-                                then
-                                    final_successor = pretender
+                                if pretender ~= character and pretender.home_province == realm.capitol then
+                                    if
+                                        final_successor == nil
+                                    then
+                                        final_successor = pretender
+                                    elseif
+                                        pv.popularity(pretender, realm) > pv.popularity(final_successor, realm)
+                                    then
+                                        final_successor = pretender
+                                    end
                                 end
                             end
 
@@ -57,25 +58,28 @@ local function load()
                     if not successor then
                         ---@type Character?
                         local final_successor = nil
+                        -- attempt to find a realm noble outside capitol
                         for _, pretender in pairs(capitol.home_to) do
-                            if
-                                final_successor == nil
-                                and pretender:is_character()
-                                and pretender ~= character
-                            then
-                                final_successor = pretender
-                            elseif
-                                pretender:is_character()
-                                and pv.popularity(pretender, realm) > pv.popularity(final_successor, realm)
-                                and pretender ~= character
-                            then
-                                final_successor = pretender
+                            if pretender ~= character then
+                                if
+                                    final_successor == nil
+                                    and pretender:is_character()
+                                then
+                                    final_successor = pretender
+                                elseif
+                                    pretender:is_character()
+                                    and pv.popularity(pretender, realm) > pv.popularity(final_successor, realm)
+                                then
+                                    final_successor = pretender
+                                end
                             end
                         end
 
                         successor = final_successor
                     end
+                    -- failing to find any realm nobles
                     if not successor then
+                        -- attempt to get any local tribe pop
                         successor = tabb.random_select_from_set(tabb.filter(capitol.home_to, function (a)
                             return a.province and a.province == capitol and not a:is_character()
                         end))
@@ -83,24 +87,6 @@ local function load()
                             pe.grant_nobility(successor, capitol, pe.reasons.NOT_ENOUGH_NOBLES)
                         end
                     end
-                    if not successor then
-                        successor = pe.grant_nobility_to_random_pop(capitol, pe.reasons.NOT_ENOUGH_NOBLES)
-                        if successor then
-                            -- at this point the original tribe is extinquished and a new tribe rise to fill the vacuum
-                            capitol.realm.primary_culture = successor.culture
-                            capitol.realm.primary_faith = successor.faith
-                            capitol.realm.primary_race = successor.race
-                            capitol.realm.name = successor.culture.language:get_random_realm_name()
-                            capitol.name = successor.culture.language:get_random_province_name()
-                            -- grab whatever similar pops you can and set their home to give the new realm pop
-                            for _, v in pairs(tabb.filter(capitol.all_pops, function (a)
-                                return a.culture == successor.culture and a.faith == successor.faith and a.race == successor.race
-                            end)) do
-                                capitol:set_home(v)
-                            end
-                        end
-                    end
-
                     if successor then
                         pe.transfer_power(realm, successor, pe.reasons.SUCCESSION)
                         WORLD:emit_immediate_event("succession-leader-notification", successor, realm)
@@ -108,6 +94,59 @@ local function load()
                         -- no pops left: destroy realm
                         pe.dissolve_realm(realm)
                         realm.leader = nil
+                        -- at this point the original realm is extinquished and a new realm rises to fill the vacuum
+                        if tabb.size(capitol.all_pops) then
+                            -- make new realm for remaining pop
+                            local r = require "game.entities.realm".Realm:new()
+                            r.capitol = capitol
+                            r:add_province(capitol)
+                            r:explore(capitol)
+                            --attempt to find random local character to fill vaccuum
+                            for _, pretender in pairs(capitol.characters) do
+                                if pretender ~= character and pretender.home_province == realm.capitol then
+                                    if
+                                        successor == nil
+                                    then
+                                        successor = pretender
+                                    elseif
+                                        pv.popularity(pretender, realm) > pv.popularity(successor, realm)
+                                    then
+                                        successor = pretender
+                                    end
+                                end
+                            end
+                            --failing all else, grab random pop and make noble
+                            if not successor then
+                                successor = pe.grant_nobility_to_random_pop(capitol, pe.reasons.INITIAL_NOBLE)
+                            end
+                            -- use new leader to finish setting up the new realm
+                            if successor then
+                                pe.transfer_power(r, successor, pe.reasons.INITIAL_RULER)
+                                local culture = successor.culture
+                                r.primary_race = successor.race
+                                r.primary_culture = culture
+                                r.primary_faith = successor.faith
+                                -- Initialize realm colors
+                                r.r = math.max(0, math.min(1, (culture.r + (love.math.random() * 0.4 - 0.2))))
+                                r.g = math.max(0, math.min(1, (culture.g + (love.math.random() * 0.4 - 0.2))))
+                                r.b = math.max(0, math.min(1, (culture.b + (love.math.random() * 0.4 - 0.2))))
+                                r.name = culture.language:get_random_realm_name()
+                                capitol.name = culture.language:get_random_province_name()
+                                for _, neigh in pairs(capitol.neighbors) do
+                                    r:explore(neigh)
+                                end
+                                -- grab whatever similar pops you can and set their home to give the new realm pop
+                                for _, v in pairs(tabb.filter(capitol.all_pops, function (a)
+                                    return a.culture == successor.culture and a.faith == successor.faith and a.race == successor.race
+                                end)) do
+                                    capitol:set_home(v)
+                                end
+                            else
+                                -- if we can't manage to grab a successor from characters or all_pops
+                                -- cancel making a a new realm - shouldn't be possible! just in case
+                                pe.dissolve_realm(r)
+                            end
+                        end
                     end
                 end
 
@@ -180,7 +219,7 @@ local function load()
             -- loyalty reset
             ie.remove_all_loyal(character)
 
-            -- clear references to character
+-- clear references to character
             character.province:remove_character(character)
             character.home_province:unset_home(character)
 		end,

--- a/sote/game/raws/events/succession.lua
+++ b/sote/game/raws/events/succession.lua
@@ -3,6 +3,8 @@ local E_ut = require "game.raws.events._utils"
 
 local ut = require "game.ui-utils"
 
+local tabb = require "engine.table"
+
 local pe = require "game.raws.effects.political"
 local pv = require "game.raws.values.political"
 local ee = require "game.raws.effects.economic"
@@ -73,7 +75,11 @@ local function load()
 
                         successor = final_successor
                     end
-
+                    if not successor then
+                        successor = pe.grant_nobility(tabb.filter(capitol.home_to, function (a)
+                            return not a:is_character() and a.province == capitol
+                        end), capitol, pe.reasons.NOT_ENOUGH_NOBLES)
+                    end
                     if not successor then
                         successor = pe.grant_nobility_to_random_pop(capitol, pe.reasons.NOT_ENOUGH_NOBLES)
                     end

--- a/sote/game/raws/events/succession.lua
+++ b/sote/game/raws/events/succession.lua
@@ -10,6 +10,7 @@ local pv = require "game.raws.values.political"
 local ee = require "game.raws.effects.economic"
 local me = require "game.raws.effects.military"
 local ie = require "game.raws.effects.interpersonal"
+local di = require "game.raws.effects.diplomacy"
 
 local offices_triggers = require "game.raws.triggers.offices"
 
@@ -92,7 +93,7 @@ local function load()
                         WORLD:emit_immediate_event("succession-leader-notification", successor, realm)
                     else
                         -- no pops left: destroy realm
-                        pe.dissolve_realm(realm)
+                        di.dissolve_realm_and_clear_diplomacy(realm)
                         realm.leader = nil
                         -- at this point the original realm is extinquished and a new realm rises to fill the vacuum
                         if tabb.size(capitol.all_pops) then

--- a/sote/game/raws/events/succession.lua
+++ b/sote/game/raws/events/succession.lua
@@ -76,12 +76,29 @@ local function load()
                         successor = final_successor
                     end
                     if not successor then
-                        successor = pe.grant_nobility(tabb.filter(capitol.home_to, function (a)
-                            return not a:is_character() and a.province == capitol
-                        end), capitol, pe.reasons.NOT_ENOUGH_NOBLES)
+                        successor = tabb.random_select_from_set(tabb.filter(capitol.home_to, function (a)
+                            return a.province and a.province == capitol and not a:is_character()
+                        end))
+                        if successor then
+                            pe.grant_nobility(successor, capitol, pe.reasons.NOT_ENOUGH_NOBLES)
+                        end
                     end
                     if not successor then
                         successor = pe.grant_nobility_to_random_pop(capitol, pe.reasons.NOT_ENOUGH_NOBLES)
+                        if successor then
+                            -- at this point the original tribe is extinquished and a new tribe rise to fill the vacuum
+                            capitol.realm.primary_culture = successor.culture
+                            capitol.realm.primary_faith = successor.faith
+                            capitol.realm.primary_race = successor.race
+                            capitol.realm.name = successor.culture.language:get_random_realm_name()
+                            capitol.name = successor.culture.language:get_random_province_name()
+                            -- grab whatever similar pops you can and set their home to give the new realm pop
+                            for _, v in pairs(tabb.filter(capitol.all_pops, function (a)
+                                return a.culture == successor.culture and a.faith == successor.faith and a.race == successor.race
+                            end)) do
+                                capitol:set_home(v)
+                            end
+                        end
                     end
 
                     if successor then

--- a/sote/game/raws/events/succession.lua
+++ b/sote/game/raws/events/succession.lua
@@ -220,7 +220,7 @@ local function load()
             -- loyalty reset
             ie.remove_all_loyal(character)
 
--- clear references to character
+            -- clear references to character
             character.province:remove_character(character)
             character.home_province:unset_home(character)
 		end,

--- a/sote/game/scenes/game/realm-inspector.lua
+++ b/sote/game/scenes/game/realm-inspector.lua
@@ -177,6 +177,141 @@ function re.draw(gam)
 						end
 					end
 					a.y = a.y + uit.BASE_HEIGHT
+
+					local inspect = nil
+					local function render_name(rect, k, v)
+						if uit.text_button(v.name, rect) then
+							inspect = "character"
+							return v
+						end
+					end
+					local function render_province(rect, k, v)
+						if uit.text_button(v.province.name, rect) then
+							inspect = "tile"
+							return v.province
+						end
+					end
+					local function pop_sex(pop)
+						local f = "m"
+						if pop.female then f = "f" end
+						return f
+					end
+					local noble_list = a:copy()
+					noble_list.width = ui_panel.width - ui_panel.x
+					noble_list.height = ui_panel.height - ui_panel.y
+					local response = require "game.scenes.game.widgets.list-widget"(
+						noble_list,
+						tabb.filter(realm.capitol.home_to,
+							function(a)
+								return a:is_character()
+							end),
+							{
+								{
+									header = ".",
+									render_closure = function(rect, k, v)
+										require "game.scenes.game.widgets.portrait"(rect, v)
+									end,
+									width = UI_STYLE.scrollable_list_item_height,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.race.name
+									end
+								},
+								{
+									header = "name",
+									render_closure = render_name,
+									width = UI_STYLE.scrollable_list_item_height * 4,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.name
+									end,
+									active = true
+								},
+								{
+									header = "location",
+									render_closure = render_province,
+									width = UI_STYLE.scrollable_list_item_height * 4,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.province.name
+									end,
+									active = true
+								},
+								{
+									header = "race",
+									render_closure = function (rect, k, v)
+										ui.right_text(v.race.name, rect)
+									end,
+									width = UI_STYLE.scrollable_list_item_height * 4,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.race.name
+									end,
+									active = true
+								},
+								{
+									header = "faith",
+									render_closure = function (rect, k, v)
+										ui.right_text(v.faith.name, rect)
+									end,
+									width = UI_STYLE.scrollable_list_item_height * 4,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.faith.name
+									end,
+									active = true
+								},
+								{
+									header = "culture",
+									render_closure = function (rect, k, v)
+										ui.right_text(v.culture.name, rect)
+									end,
+									width = UI_STYLE.scrollable_list_item_height * 4,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.culture.name
+									end,
+									active = true
+								},
+								{
+									header = "age",
+									render_closure = function (rect, k, v)
+										ui.right_text(tostring(v.age), rect)
+									end,
+									width = UI_STYLE.scrollable_list_item_height * 2,
+									value = function(k, v)
+										return v.age
+									end
+								},
+								{
+									header = "sex",
+									render_closure = function (rect, k, v)
+										ui.centered_text(pop_sex(v), rect)
+									end,
+									width = UI_STYLE.scrollable_list_item_height * 1,
+									value = function(k, v)
+										return pop_sex(v)
+									end
+								}
+							}
+					)()
+					if response then
+						if inspect == "character" then
+							gam.selected.character = response
+							gam.inspector = inspect
+						elseif inspect == "tile" then
+							gam.selected.province = response
+							gam.selected.tile = response.center
+							gam.clicked_tile_id = response.center.tile_id
+							gam.inspector = inspect
+						end
+					end
 				end
 			},
 			-- {

--- a/sote/game/scenes/game/realm-inspector.lua
+++ b/sote/game/scenes/game/realm-inspector.lua
@@ -231,17 +231,6 @@ function re.draw(gam)
 									active = true
 								},
 								{
-									header = "location",
-									render_closure = render_province,
-									width = UI_STYLE.scrollable_list_item_height * 4,
-									value = function(k, v)
-										---@type POP
-										v = v
-										return v.province.name
-									end,
-									active = true
-								},
-								{
 									header = "race",
 									render_closure = function (rect, k, v)
 										ui.right_text(v.race.name, rect)
@@ -299,6 +288,17 @@ function re.draw(gam)
 									value = function(k, v)
 										return pop_sex(v)
 									end
+								},
+								{
+									header = "location",
+									render_closure = render_province,
+									width = UI_STYLE.scrollable_list_item_height * 4,
+									value = function(k, v)
+										---@type POP
+										v = v
+										return v.province.name
+									end,
+									active = true
 								}
 							}
 					)()

--- a/sote/game/scenes/game/realm-inspector.lua
+++ b/sote/game/scenes/game/realm-inspector.lua
@@ -175,6 +175,7 @@ function re.draw(gam)
 								EconomicEffects.reasons.Court
 							)
 						end
+						a.y = a.y + uit.BASE_HEIGHT
 					end
 					a.y = a.y + uit.BASE_HEIGHT
 

--- a/sote/game/society/court.lua
+++ b/sote/game/society/court.lua
@@ -68,11 +68,13 @@ function co.run(realm)
 	for _, prov in pairs(realm.provinces) do
 		local p = {nobles = 0, population = 0, elligible = {}}
 		tabb.accumulate(prov.home_to, p, function (a, k, v)
-			if v:is_character() then
-				a.nobles = a.nobles + 1
-			else
-				a.population = a.population + 1
-				a.elligible[k] = v
+			if v.province == prov then
+				if v:is_character() then
+					a.nobles = a.nobles + 1
+				else
+					a.population = a.population + 1
+					a.elligible[k] = v
+				end
 			end
 			return a
 		end)


### PR DESCRIPTION
I forgot to included parent-child management when uplifting pop to character in the parent-child tracking PR. This fixes that by simply removing the pop from any parent or child variable it could be assigned to or have assigned to it. And limits the random to only consider home characters, so it won't uplift warriors accompanying traveling characters.
Edit:
After a 100 year test run, I noticed that the change from home_to noble picking was ending up with deleted tribes in provinces full of goblins. This was even happening the most in goblin provinces and was curious why. After a a few failed attempts to get the succession check to dissolve the realm and make a new one base on the pop I decided to revert this change and find another approach.
Ultimately, I went after the court function and made it's noble uplift only target a ratio from pops in the home_to table and just pick a random home_to pop in succession before trying from all_pop if there was no home characters left pop to pull up.
In my attempt to track this in action, I added a list of nobles from the home_to table in the court to see how many nobles of a realm were left and watch the peaceful transition of power from one race to another only when the tribe died out completely.
To my surprise I found that the home_to table is never set despite being cleared many times. This means no province considered any pops home and any call to the home_to table was always empty. After fixing the set function to actually set the key-value pair instead of calling the clear wrapper, it now sets every starting pop to a bidirectional relationship between the home_to table and home_province variables.
Using this home_to table properly now allows a court to only raise up nobles based on its lawful tribe membership not just because there are a lot of foreigners hanging around and conversely will not have provinces with lots of guest characters block uplifting pop to nobles when they have a small population. Now foreign goblins breeding in a province wont force a tribe to eat it's own pop into nobles to match the desired ratio.